### PR TITLE
Disable Farcaster integrations

### DIFF
--- a/apps/nouns-camp/src/app/api/farcaster-account-key/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-account-key/route.js
@@ -5,6 +5,7 @@ import {
   persistPendingAccountKeyForFid,
   setPendingAccountKey,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 const SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_DOMAIN = {
   name: "Farcaster SignedKeyRequestValidator",
@@ -107,6 +108,8 @@ const fetchAccountKey = async (publicKey) => {
 };
 
 export async function POST() {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { publicKey, privateKey } = await createSignerKeyPair();
 
   const keyRequest = await createSignedKeyRequest(publicKey);
@@ -117,6 +120,8 @@ export async function POST() {
 }
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const publicKey = searchParams.get("key");
 

--- a/apps/nouns-camp/src/app/api/farcaster-accounts/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-accounts/route.js
@@ -1,9 +1,12 @@
 import { kv } from "@vercel/kv";
 import { isAddress } from "viem";
 import { fetchAccountsWithVerifiedAddress } from "@/app/api/farcaster-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 // Returns Farcaster accounts matching a verified Ethereum account address
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const ethAddress = searchParams.get("eth-address");
 

--- a/apps/nouns-camp/src/app/api/farcaster-candidate-casts/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-candidate-casts/route.js
@@ -13,6 +13,7 @@ import {
   getAccountKeyForFid,
   deleteAccountKeyForFid,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 const createCanonicalCandidateUrl = async (candidateId) => {
   const { proposalCandidate } = await subgraphFetch({
@@ -39,6 +40,8 @@ const fetchCandidateCasts = async (candidateId) => {
 };
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const candidateId = searchParams.get("candidate");
 
@@ -58,6 +61,8 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { candidateId, text, fid } = await request.json();
 
   if (!(await isLoggedIn()))

--- a/apps/nouns-camp/src/app/api/farcaster-cast-conversation/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-cast-conversation/route.js
@@ -1,6 +1,9 @@
 import { fetchCastReplies } from "@/app/api/farcaster-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const hash = searchParams.get("hash");
 

--- a/apps/nouns-camp/src/app/api/farcaster-cast-likes/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-cast-likes/route.js
@@ -10,8 +10,11 @@ import {
   getAccountKeyForFid,
   deleteAccountKeyForFid,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const hash = searchParams.get("hash");
 
@@ -36,6 +39,8 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { targetCastId, fid, action } = await request.json();
 
   if (!(await isLoggedIn()))

--- a/apps/nouns-camp/src/app/api/farcaster-casts/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-casts/route.js
@@ -3,6 +3,7 @@ import { CHAIN_ID } from "@/constants/env";
 import { subgraphFetch } from "@/nouns-subgraph";
 import { createUri as createTransactionReceiptUri } from "@/utils/erc-2400";
 import { fetchCastsByParentUrl } from "@/app/api/farcaster-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 const DAY_THRESHOLD = 14;
 const CAST_LIMIT_PER_PROP = 20;
@@ -67,6 +68,8 @@ const jsonResponse = (statusCode, body, headers) =>
   });
 
 export async function GET() {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { casts, accounts } = await fetchRecentCasts();
 
   return jsonResponse(

--- a/apps/nouns-camp/src/app/api/farcaster-disabled-response.js
+++ b/apps/nouns-camp/src/app/api/farcaster-disabled-response.js
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { FARCASTER_ENABLED } from "@/constants/features";
+
+export const ensureFarcasterEnabled = () => {
+  if (FARCASTER_ENABLED) return null;
+  return NextResponse.json(
+    { error: "Farcaster features are temporarily disabled." },
+    { status: 503 },
+  );
+};

--- a/apps/nouns-camp/src/app/api/farcaster-proposal-casts/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-proposal-casts/route.js
@@ -12,6 +12,7 @@ import {
   getAccountKeyForFid,
   deleteAccountKeyForFid,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 const createCanonicalProposalUrl = async (proposalId) => {
   const { proposal } = await subgraphFetch({
@@ -35,6 +36,8 @@ const fetchProposalCasts = async (proposalId) => {
 };
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const proposalId = searchParams.get("proposal");
 
@@ -54,6 +57,8 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { proposalId, text, fid } = await request.json();
 
   if (!(await isLoggedIn()))

--- a/apps/nouns-camp/src/app/api/farcaster-replies/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-replies/route.js
@@ -6,8 +6,11 @@ import {
   getAccountKeyForFid,
   deleteAccountKeyForFid,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 export async function POST(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { targetCastId, text, fid } = await request.json();
 
   if (!(await isLoggedIn()))

--- a/apps/nouns-camp/src/app/api/farcaster-transaction-likes/route.js
+++ b/apps/nouns-camp/src/app/api/farcaster-transaction-likes/route.js
@@ -11,8 +11,11 @@ import {
   getAccountKeyForFid,
   deleteAccountKeyForFid,
 } from "@/app/api/farcaster-account-key-utils";
+import { ensureFarcasterEnabled } from "@/app/api/farcaster-disabled-response";
 
 export async function GET(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { searchParams } = new URL(request.url);
   const hash = searchParams.get("hash");
 
@@ -38,6 +41,8 @@ export async function GET(request) {
 }
 
 export async function POST(request) {
+  const disabledResponse = ensureFarcasterEnabled();
+  if (disabledResponse) return disabledResponse;
   const { transactionHash, fid, action } = await request.json();
 
   if (!(await isLoggedIn()))

--- a/apps/nouns-camp/src/app/layout.jsx
+++ b/apps/nouns-camp/src/app/layout.jsx
@@ -14,6 +14,7 @@ import GlobalStylesWrapper from "@/global-styles-wrapper";
 import SessionProvider from "@/session-provider";
 import { Provider as StoreProvider } from "@/store";
 import { Provider as FarcasterStateProvider } from "@/hooks/farcaster";
+import { FARCASTER_ENABLED } from "@/constants/features";
 // MobileDevTools will be lazy-loaded in development and preview deployments
 import { lazy, Suspense } from "react";
 const MobileDevTools = lazy(() => import("@/components/mobile-devtools"));
@@ -121,15 +122,27 @@ export default async function RootLayout({ children }) {
                       initialSession={{ address: session.address }}
                     >
                       <StoreProvider>
-                        <FarcasterStateProvider>
-                          {children}
-                          {(process.env.NODE_ENV === "development" ||
-                            process.env.VERCEL_ENV === "preview") && (
-                            <Suspense fallback={null}>
-                              <MobileDevTools />
-                            </Suspense>
-                          )}
-                        </FarcasterStateProvider>
+                        {FARCASTER_ENABLED ? (
+                          <FarcasterStateProvider>
+                            {children}
+                            {(process.env.NODE_ENV === "development" ||
+                              process.env.VERCEL_ENV === "preview") && (
+                              <Suspense fallback={null}>
+                                <MobileDevTools />
+                              </Suspense>
+                            )}
+                          </FarcasterStateProvider>
+                        ) : (
+                          <>
+                            {children}
+                            {(process.env.NODE_ENV === "development" ||
+                              process.env.VERCEL_ENV === "preview") && (
+                              <Suspense fallback={null}>
+                                <MobileDevTools />
+                              </Suspense>
+                            )}
+                          </>
+                        )}
                       </StoreProvider>
                     </SessionProvider>
                   </WagmiProvider>

--- a/apps/nouns-camp/src/components/account-authentication-dialog.js
+++ b/apps/nouns-camp/src/components/account-authentication-dialog.js
@@ -9,6 +9,7 @@ import { useDialog } from "@/hooks/global-dialogs";
 import { useConnectedFarcasterAccounts } from "@/hooks/farcaster";
 import { pickDisplayName as pickFarcasterAccountDisplayName } from "@/utils/farcaster";
 import { reportError } from "@/utils/monitoring";
+import { FARCASTER_ENABLED } from "@/constants/features";
 
 const AccountAuthenticationDialog = ({ isOpen, close }) => {
   const { isAuthenticated } = useWallet();
@@ -29,7 +30,10 @@ const Content = ({ titleProps, dismiss }) => {
   const { isAuthenticated } = useWallet();
   const { signIn: authenticateConnectedAccount, state: authenticationState } =
     useWalletAuthentication();
-  const connectedFarcasterAccount = useConnectedFarcasterAccounts()?.[0];
+  const connectedFarcasterAccounts = useConnectedFarcasterAccounts();
+  const connectedFarcasterAccount = FARCASTER_ENABLED
+    ? connectedFarcasterAccounts?.[0]
+    : null;
   const { data: dialogData } = useDialog("account-authentication");
   const userIntent = dialogData?.intent;
   const onSuccess = dialogData?.onSuccess;
@@ -66,7 +70,8 @@ const Content = ({ titleProps, dismiss }) => {
         {isAuthenticated ? (
           <>
             {(() => {
-              if (connectedFarcasterAccount == null) return null;
+              if (!FARCASTER_ENABLED || connectedFarcasterAccount == null)
+                return null;
               const { pfpUrl } = connectedFarcasterAccount;
               const displayName = pickFarcasterAccountDisplayName(
                 connectedFarcasterAccount,

--- a/apps/nouns-camp/src/components/account-preview-popover-trigger.js
+++ b/apps/nouns-camp/src/components/account-preview-popover-trigger.js
@@ -30,6 +30,7 @@ import { useAccountsWithVerifiedEthAddress as useFarcasterAccountsWithVerifiedEt
 import AccountAvatar from "@/components/account-avatar";
 import NounPreviewPopoverTrigger from "@/components/noun-preview-popover-trigger";
 import NextLink from "next/link";
+import { FARCASTER_ENABLED } from "@/constants/features";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -142,8 +143,9 @@ const AccountPreviewPopoverTrigger = React.forwardRef(
 const AccountPreview = React.forwardRef(({ accountAddress, close }, ref) => {
   const { address: connectedAccountAddress } = useWallet();
   const connectedAccount = useAccount(connectedAccountAddress);
-  const farcasterAccounts =
+  const farcasterAccountsData =
     useFarcasterAccountsWithVerifiedEthAddress(accountAddress);
+  const farcasterAccounts = FARCASTER_ENABLED ? farcasterAccountsData : null;
 
   const isMe = accountAddress.toLowerCase() === connectedAccountAddress;
   const enableImpersonation = !isMe && (!isProduction || isDebugSession);
@@ -585,7 +587,7 @@ const AccountPreview = React.forwardRef(({ accountAddress, close }, ref) => {
                 },
               ]}
               onAction={(key) => {
-                if (key.startsWith("open-warpcast:")) {
+                if (FARCASTER_ENABLED && key.startsWith("open-warpcast:")) {
                   const fid = key.split(":")[1];
                   const farcasterAccount = farcasterAccounts.find(
                     (a) => String(a.fid) === fid,

--- a/apps/nouns-camp/src/components/farcaster-setup-dialog.jsx
+++ b/apps/nouns-camp/src/components/farcaster-setup-dialog.jsx
@@ -17,6 +17,7 @@ import { useDialog } from "@/hooks/global-dialogs";
 import { useConnectedFarcasterAccounts } from "@/hooks/farcaster";
 import LogoSymbol from "@/components/logo-symbol";
 import ChainExplorerAddressLink from "@/components/chain-explorer-address-link";
+import { FARCASTER_ENABLED } from "@/constants/features";
 
 const createFarcasterAccountKey = async () => {
   const res = await fetch("/api/farcaster-account-key", { method: "POST" });
@@ -40,6 +41,8 @@ const getFarcasterAccountKey = async (publicKey) => {
 
 const FarcasterSetupDialog = ({ isOpen, close }) => {
   const { address: connectedAccountAddress } = useWallet();
+
+  if (!FARCASTER_ENABLED) return null;
 
   return (
     <Dialog
@@ -82,7 +85,7 @@ const FarcasterSetupContent = ({ titleProps, dismiss }) => {
       setKeyData((s) => ({ ...s, ...data }));
     },
     {
-      enabled: keyData != null,
+      enabled: FARCASTER_ENABLED && keyData != null,
       fetchInterval: 3000,
     },
     [keyData?.key],
@@ -93,6 +96,7 @@ const FarcasterSetupContent = ({ titleProps, dismiss }) => {
     refetchInterval: 2500,
   });
 
+  if (!FARCASTER_ENABLED) return null;
   if (accounts == null) return null;
 
   const hasVerifiedAddress = accounts.length > 0;

--- a/apps/nouns-camp/src/components/layout.jsx
+++ b/apps/nouns-camp/src/components/layout.jsx
@@ -26,6 +26,7 @@ import {
 } from "@/session-provider";
 import { useDialog } from "@/hooks/global-dialogs";
 import { useConnectedFarcasterAccounts } from "@/hooks/farcaster";
+import { FARCASTER_ENABLED } from "@/constants/features";
 import useAccountDisplayName from "@/hooks/account-display-name";
 import {
   useAuctionData,
@@ -357,10 +358,11 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
   const { address: loggedInAccountAddress } = useSessionState();
   const { destroy: signOut } = useSessionActions();
   const connectedFarcasterAccounts = useConnectedFarcasterAccounts();
-  const hasVerifiedFarcasterAccount = connectedFarcasterAccounts?.length > 0;
+  const hasVerifiedFarcasterAccount =
+    FARCASTER_ENABLED && connectedFarcasterAccounts?.length > 0;
   const hasFarcasterAccountKey =
     hasVerifiedFarcasterAccount &&
-    connectedFarcasterAccounts.some((a) => a.hasAccountKey);
+    connectedFarcasterAccounts?.some((a) => a.hasAccountKey);
 
   const userAccountAddress =
     connectedWalletAccountAddress ?? loggedInAccountAddress;
@@ -408,12 +410,14 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
         navigator.clipboard.writeText(userAccountAddress);
         break;
       case "open-warpcast":
+        if (!FARCASTER_ENABLED) break;
         window.open("https://warpcast.com/~/channel/nouns", "_blank");
         break;
       case "open-flows":
         window.open("https://flows.wtf", "_blank");
         break;
       case "open-camp-changelog":
+        if (!FARCASTER_ENABLED) break;
         window.open("https://warpcast.com/~/channel/camp", "_blank");
         break;
       case "open-camp-discord":
@@ -447,6 +451,7 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
         openTreasuryDialog();
         break;
       case "setup-farcaster":
+        if (!FARCASTER_ENABLED) break;
         openFarcasterSetupDialog();
         break;
       case "sign-in": {
@@ -771,7 +776,7 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                 id: "external",
                 title: "External",
                 children: [
-                  {
+                  FARCASTER_ENABLED && {
                     id: "open-warpcast",
                     title: "Farcaster",
                     iconRight: <span>{"\u2197"}</span>,
@@ -781,14 +786,14 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                     title: "Flows",
                     iconRight: <span>{"\u2197"}</span>,
                   },
-                ],
+                ].filter(Boolean),
               };
               const settingsSection = {
                 id: "settings",
                 title: "Camp",
                 children: [
                   { id: "open-settings-dialog", title: "Settings" },
-                  {
+                  FARCASTER_ENABLED && {
                     id: "open-camp-changelog",
                     title: "Changelog",
                     iconRight: <span>{"\u2197"}</span>,
@@ -803,7 +808,7 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                     title: "GitHub",
                     iconRight: <span>{"\u2197"}</span>,
                   },
-                ],
+                ].filter(Boolean),
               };
 
               if (connectedWalletAccountAddress == null)
@@ -853,9 +858,8 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                         id: "open-drafts-dialog",
                         title: "Proposal & topic drafts",
                       },
-                      !hasVerifiedFarcasterAccount
-                        ? null
-                        : !hasFarcasterAccountKey
+                      FARCASTER_ENABLED && hasVerifiedFarcasterAccount
+                        ? !hasFarcasterAccountKey
                           ? {
                               id: "setup-farcaster",
                               title: "Setup Farcaster",
@@ -865,7 +869,8 @@ const NavBar = ({ navigationStack, actions: customActions }) => {
                                 id: "sign-in",
                                 title: "Authenticate account",
                               }
-                            : null,
+                            : null
+                        : null,
                     ].filter(Boolean),
                   },
                   daoSection,

--- a/apps/nouns-camp/src/components/settings-dialog.js
+++ b/apps/nouns-camp/src/components/settings-dialog.js
@@ -6,6 +6,7 @@ import config from "@/config";
 import useSetting, { getConfig as getSettingConfig } from "@/hooks/setting";
 import { useSearchParams } from "@/hooks/navigation";
 import { useWallet } from "@/hooks/wallet";
+import { FARCASTER_ENABLED } from "@/constants/features";
 
 const BUILD_ID = process.env.BUILD_ID;
 
@@ -105,7 +106,7 @@ const Content = ({ titleProps, dismiss }) => {
           state: zoom,
           setState: setZoom,
         },
-        {
+        FARCASTER_ENABLED && {
           key: "farcaster-cast-filter",
           state: farcasterFilter,
           setState: setFarcasterFilter,

--- a/apps/nouns-camp/src/components/voter-screen.jsx
+++ b/apps/nouns-camp/src/components/voter-screen.jsx
@@ -45,6 +45,7 @@ import NounPreviewPopoverTrigger from "@/components/noun-preview-popover-trigger
 import ProposalList from "@/components/sectioned-list";
 import { buildEtherscanLink } from "@/utils/etherscan";
 import { useAccountsWithVerifiedEthAddress as useFarcasterAccountsWithVerifiedEthAddress } from "@/hooks/farcaster";
+import { FARCASTER_ENABLED } from "@/constants/features";
 import Avatar from "@shades/ui-web/avatar";
 import AccountPreviewPopoverTrigger from "@/components/account-preview-popover-trigger";
 import useEnsText from "@/hooks/ens-text";
@@ -457,8 +458,9 @@ const VoterHeader = ({ accountAddress }) => {
       ? displayName_
       : matchingContract.name;
 
-  const farcasterAccounts =
+  const farcasterAccountsData =
     useFarcasterAccountsWithVerifiedEthAddress(accountAddress);
+  const farcasterAccounts = FARCASTER_ENABLED ? farcasterAccountsData : null;
 
   const representedNouns = delegate?.nounsRepresented ?? [];
 
@@ -635,7 +637,7 @@ const VoterHeader = ({ accountAddress }) => {
                   },
                 ]}
                 onAction={(key) => {
-                  if (key.startsWith("open-warpcast:")) {
+                  if (FARCASTER_ENABLED && key.startsWith("open-warpcast:")) {
                     const fid = key.split(":")[1];
                     const farcasterAccount = farcasterAccounts.find(
                       (a) => String(a.fid) === fid,

--- a/apps/nouns-camp/src/constants/features.js
+++ b/apps/nouns-camp/src/constants/features.js
@@ -1,0 +1,1 @@
+export const FARCASTER_ENABLED = false;

--- a/apps/nouns-camp/src/hooks/global-dialogs.js
+++ b/apps/nouns-camp/src/hooks/global-dialogs.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { array as arrayUtils } from "@shades/common/utils";
 import { useSearchParams } from "@/hooks/navigation";
+import { FARCASTER_ENABLED } from "@/constants/features";
 
 const ReactLazyWithPreload = (fetcher) => {
   const LazyComponent = React.lazy(fetcher);
@@ -68,7 +69,7 @@ const dialogs = [
       () => import("@/components/account-authentication-dialog"),
     ),
   },
-  {
+  FARCASTER_ENABLED && {
     key: "farcaster-setup",
     component: ReactLazyWithPreload(
       () => import("@/components/farcaster-setup-dialog"),
@@ -80,7 +81,7 @@ const dialogs = [
       () => import("@/components/streams-dialog"),
     ),
   },
-];
+].filter(Boolean);
 
 const dialogsByKey = arrayUtils.indexBy((d) => d.key, dialogs);
 

--- a/apps/nouns-camp/src/store-selectors/feeds.js
+++ b/apps/nouns-camp/src/store-selectors/feeds.js
@@ -8,6 +8,7 @@ import {
 } from "@/utils/votes-and-feedbacks";
 import { getSponsorSignatures as getCandidateSponsorSignatures } from "@/utils/candidates";
 import { pickDisplayName as pickFarcasterAccountDisplayName } from "@/utils/farcaster";
+import { FARCASTER_ENABLED } from "@/constants/features";
 import { base } from "viem/chains";
 
 const createFarcasterCastItem = (cast) => {
@@ -149,11 +150,13 @@ export const buildProposalFeed = (
         });
 
   const castItems =
-    casts?.map((c) => {
-      const item = createFarcasterCastItem(c);
-      item.proposalId = proposalId;
-      return item;
-    }) ?? [];
+    FARCASTER_ENABLED && casts != null
+      ? casts.map((c) => {
+          const item = createFarcasterCastItem(c);
+          item.proposalId = proposalId;
+          return item;
+        })
+      : [];
 
   let voteAndFeedbackPostItems = buildVoteAndFeedbackPostFeedItems({
     proposalId,
@@ -314,11 +317,13 @@ export const buildCandidateFeed = (
   const targetProposalId = candidate.latestVersion?.targetProposalId;
 
   const castItems =
-    casts?.map((c) => {
-      const item = createFarcasterCastItem(c);
-      item.candidateId = candidateId;
-      return item;
-    }) ?? [];
+    FARCASTER_ENABLED && casts != null
+      ? casts.map((c) => {
+          const item = createFarcasterCastItem(c);
+          item.candidateId = candidateId;
+          return item;
+        })
+      : [];
 
   const feedbackPostItems = includeFeedbackPosts
     ? buildVoteAndFeedbackPostFeedItems({

--- a/apps/nouns-camp/wrangler.jsonc
+++ b/apps/nouns-camp/wrangler.jsonc
@@ -9,34 +9,34 @@
     "nodejs_compat",
     // Allow to fetch URLs in your app
     // see https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public
-    "global_fetch_strictly_public"
+    "global_fetch_strictly_public",
   ],
   "assets": {
     "directory": ".open-next/assets",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
   },
   "services": [
     {
       "binding": "WORKER_SELF_REFERENCE",
       // The service should match the "name" of your worker
-      "service": "nouners"
-    }
+      "service": "nouners",
+    },
   ],
   "r2_buckets": [
     {
       "binding": "NEXT_INC_CACHE_R2_BUCKET",
-      "bucket_name": "nouners"
-    }
+      "bucket_name": "nouners",
+    },
   ],
   "kv_namespaces": [
     {
       "binding": "KV",
-      "id": "d8b9ad73f5054ec081a27603fabc1da5"
-    }
+      "id": "d8b9ad73f5054ec081a27603fabc1da5",
+    },
   ],
   "observability": {
     "logs": {
-      "enabled": true
-    }
-  }
+      "enabled": true,
+    },
+  },
 }


### PR DESCRIPTION
## Summary
- add a feature flag that turns off Farcaster usage in the app
- hide Farcaster-driven UI flows and make hooks/components return safe fallbacks when disabled
- short-circuit Farcaster API routes with a 503 response while the integration is paused

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2cc18d47c832e886a0995f46b2ba8