### PR TITLE
style: replace Inter with Oxanium font

### DIFF
--- a/apps/nouns-camp/src/app/api/og-utils.js
+++ b/apps/nouns-camp/src/app/api/og-utils.js
@@ -4,15 +4,15 @@ import { ethereum as ethereumUtils } from "@shades/common/utils";
 const { truncateAddress } = ethereumUtils;
 
 export const getFonts = async () => {
-  const fontName = "Inter";
+  const fontName = "Oxanium";
 
   const semiBoldResp = await fetch(
-    new URL("../../assets/fonts/Inter-SemiBold.woff", import.meta.url),
+    new URL("../../assets/fonts/Oxanium-SemiBold.ttf", import.meta.url),
   );
   const semiBoldFontArray = await semiBoldResp.arrayBuffer();
 
   const boldResp = await fetch(
-    new URL("../../assets/fonts/Inter-Bold.woff", import.meta.url),
+    new URL("../../assets/fonts/Oxanium-Bold.ttf", import.meta.url),
   );
   const boldFontArray = await boldResp.arrayBuffer();
 

--- a/apps/nouns-camp/src/index.css
+++ b/apps/nouns-camp/src/index.css
@@ -1,9 +1,66 @@
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-ExtraLight.ttf") format("truetype");
+  font-weight: 200;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-Light.ttf") format("truetype");
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-Medium.ttf") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-SemiBold.ttf") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Oxanium";
+  src: url("./assets/fonts/Oxanium-ExtraBold.ttf") format("truetype");
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
+}
+
 html {
   font-size: 0.625em;
 }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
-    Arial, sans-serif;
+  font-family:
+    "Oxanium",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   margin: 0;
   font-size: 1.4rem;
   user-select: none;

--- a/packages/ui-web/src/theme-dark.js
+++ b/packages/ui-web/src/theme-dark.js
@@ -73,9 +73,9 @@ const textWeights = {
 
 const fontStacks = {
   default:
-    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    '"Oxanium", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
   headers:
-    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    '"Oxanium", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
   monospace:
     '"SFMono-Regular", Menlo, Consolas, "PT Mono", "Liberation Mono", Courier, monospace',
   // 'ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Ubuntu Mono", "Roboto Mono", Menlo, Monaco, Consolas, monospace',


### PR DESCRIPTION
## Summary
- register Oxanium font-face declarations and use the family globally
- update the shared UI theme font stack to prefer Oxanium while preserving fallbacks
- switch OG font loading to Oxanium assets

## Testing
- pnpm -F nouns-camp lint
- pnpm -F nouns-camp test *(fails: Invalid PostCSS Plugin)*
- pnpm -F @shades/ui-web lint

------
https://chatgpt.com/codex/tasks/task_e_68e2d6ff30d8832eb5a1507f4d1d6c5f