### PR TITLE
Ensure Farcaster provider always wraps layout children

### DIFF
--- a/apps/nouns-camp/src/app/layout.jsx
+++ b/apps/nouns-camp/src/app/layout.jsx
@@ -97,6 +97,10 @@ const fetchConfig = async () => {
 
 export default async function RootLayout({ children }) {
   const [session, config] = await Promise.all([getSession(), fetchConfig()]);
+  const shouldShowMobileDevTools =
+    process.env.NODE_ENV === "development" ||
+    process.env.VERCEL_ENV === "preview";
+
   return (
     <html lang="en">
       <body>
@@ -121,10 +125,10 @@ export default async function RootLayout({ children }) {
                       initialSession={{ address: session.address }}
                     >
                       <StoreProvider>
+                        {/* Always mount the Farcaster provider; it supplies a no-op context when disabled. */}
                         <FarcasterStateProvider>
                           {children}
-                          {(process.env.NODE_ENV === "development" ||
-                            process.env.VERCEL_ENV === "preview") && (
+                          {shouldShowMobileDevTools && (
                             <Suspense fallback={null}>
                               <MobileDevTools />
                             </Suspense>


### PR DESCRIPTION
## Summary
- compute a shared `shouldShowMobileDevTools` flag in the layout and reuse it for the suspense boundary
- document that the Farcaster provider stays mounted so it can supply the disabled no-op state

## Testing
- pnpm -F nouns-camp lint
- pnpm -F nouns-camp test *(fails: Failed to load PostCSS config: Invalid PostCSS Plugin found at: plugins[0])*

------
https://chatgpt.com/codex/tasks/task_e_68e2e3f334c8832e979fd22cd54a7aff