### PR TITLE
fix: normalize weth amount formatting

### DIFF
--- a/apps/nouns-camp/src/components/proposal-screen.jsx
+++ b/apps/nouns-camp/src/components/proposal-screen.jsx
@@ -1597,7 +1597,11 @@ const RequestedAmounts = ({ amounts }) => (
             return (
               <FormattedEthWithConditionalTooltip
                 value={amount}
+                currency="weth"
+                decimals={2}
+                truncationDots={false}
                 tokenSymbol="WETH"
+                localeFormatting
               />
             );
 
@@ -1702,7 +1706,11 @@ const StreamStatus = ({ transaction }) => {
         return (
           <FormattedEthWithConditionalTooltip
             value={Number(vestedAmount)}
+            currency="weth"
+            decimals={2}
+            truncationDots={false}
             tokenSymbol="WETH"
+            localeFormatting
           />
         );
       case usdcTokenContract:

--- a/apps/nouns-camp/src/components/streams-dialog.jsx
+++ b/apps/nouns-camp/src/components/streams-dialog.jsx
@@ -493,7 +493,11 @@ const FormattedAmount = React.memo(
             return (
               <FormattedEthWithConditionalTooltip
                 value={Number(amount)}
+                currency="weth"
+                decimals={2}
+                truncationDots={false}
                 tokenSymbol="WETH"
+                localeFormatting
               />
             );
           case usdcTokenContract:


### PR DESCRIPTION
## Summary
- reuse a shared formatter helper in `FormattedEthWithConditionalTooltip` to support ETH, WETH, and USDC uniformly
- update WETH transaction explanations and stream displays to pass the new currency and locale-aware props
- align proposal stream badges with the shared WETH formatting so listings stay consistent

## Testing
- pnpm --filter nouns-camp format
- pnpm --filter nouns-camp lint
- pnpm --filter nouns-camp test *(fails: Invalid PostCSS Plugin in local env)*

------
https://chatgpt.com/codex/tasks/task_e_68f9a4cb69d0832e83c05f815b7eb353